### PR TITLE
fix: mise hooks need the experimental setting

### DIFF
--- a/ow/workspace.py
+++ b/ow/workspace.py
@@ -602,6 +602,9 @@ origin.url = "git@github.com:odoo/odoo.git"
 python = "3.12"
 node = { version = "latest", postinstall = "npm install -g rtlcss" }
 
+[settings]
+experimental = true
+
 [env]
 COMPOSE_FILE = "{{config_root}}/services/compose.yml"
 '''


### PR DESCRIPTION
~/ow/workspaces/bidule
.venv ❯ mise install
mise all tools are installed
mise WARN  Postinstall hook in ~/ow/workspaces/bidule failed: hooks is experimental. Enable it with `mise settings experimental=true`