### PR TITLE
test: raise coverage from 76% to 89% (+56 tests)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,10 +1,15 @@
+# Hidden files
+/.*
+!.github
+
+# Python
 *.egg-info
-.claude/
-.opencode/
-.ow/
-.pytest_cache
 __pycache__
-docs/superpowers/
+
+# Local documentation
+docs/
+
+# OW version
 src/ow/_version.py
 
 # OW working directories

--- a/src/tests/commands/test_init.py
+++ b/src/tests/commands/test_init.py
@@ -1,0 +1,177 @@
+import shutil
+from pathlib import Path
+
+import pytest
+
+from ow.commands.init import _copy_ow_services, _copy_packaged_templates, cmd_init
+
+
+class TestCopyPackagedTemplates:
+    def test_copies_all_template_dirs(self, tmp_path):
+        dest = tmp_path / "templates"
+        _copy_packaged_templates(dest)
+        assert dest.exists()
+        assert (dest / "common").exists()
+
+    def test_copies_nested_files(self, tmp_path):
+        dest = tmp_path / "templates"
+        _copy_packaged_templates(dest)
+        common = dest / "common"
+        assert any(common.rglob("*"))
+
+    def test_overwrites_existing(self, tmp_path):
+        dest = tmp_path / "templates"
+        dest.mkdir(parents=True)
+        (dest / "common").mkdir()
+        (dest / "common" / "mise.toml.j2").write_text("# dummy")
+        _copy_packaged_templates(dest)
+        result = (dest / "common" / "mise.toml.j2").read_text()
+        assert result != "# dummy"
+
+
+class TestCopyOwServices:
+    def test_copies_services(self, tmp_path):
+        dest = tmp_path / "services"
+        _copy_ow_services(dest)
+        assert dest.exists()
+        assert any(dest.iterdir())
+
+    def test_idempotent(self, tmp_path):
+        dest = tmp_path / "services"
+        _copy_ow_services(dest)
+        _copy_ow_services(dest)
+        assert dest.exists()
+
+
+class TestCmdInit:
+    def test_init_creates_files(self, tmp_path, capsys):
+        cmd_init(tmp_path)
+        captured = capsys.readouterr()
+        assert (tmp_path / "ow.toml").exists()
+        assert (tmp_path / "workspaces").is_dir()
+        assert (tmp_path / "templates").is_dir()
+        assert (tmp_path / "mise.toml").exists()
+        assert (tmp_path / "services").is_dir()
+        assert "Project initialized successfully" in captured.out
+
+    def test_init_default_path_is_cwd(self, tmp_path, monkeypatch, capsys):
+        monkeypatch.chdir(tmp_path)
+        cmd_init()
+        captured = capsys.readouterr()
+        assert (tmp_path / "ow.toml").exists()
+
+    def test_init_copies_packaged_templates(self, tmp_path, capsys):
+        cmd_init(tmp_path)
+        captured = capsys.readouterr()
+        tpl = tmp_path / "templates" / "common"
+        assert tpl.exists()
+        assert "Copied packaged templates" in captured.out
+
+    def test_init_copies_services(self, tmp_path, capsys):
+        cmd_init(tmp_path)
+        captured = capsys.readouterr()
+        assert (tmp_path / "services").exists()
+        assert any((tmp_path / "services").iterdir())
+        assert "Copied services" in captured.out
+
+    def test_init_creates_ow_toml_content(self, tmp_path):
+        cmd_init(tmp_path)
+        content = (tmp_path / "ow.toml").read_text()
+        assert "[vars]" in content
+        assert "[remotes.community]" in content
+        assert "git@github.com:odoo/odoo.git" in content
+
+    def test_init_creates_mise_toml_content(self, tmp_path):
+        cmd_init(tmp_path)
+        content = (tmp_path / "mise.toml").read_text()
+        assert "[tools]" in content
+
+    def test_init_prints_next_steps(self, tmp_path, capsys):
+        cmd_init(tmp_path)
+        captured = capsys.readouterr()
+        assert "Edit ow.toml" in captured.out
+        assert "mise install" in captured.out
+        assert "ow create" in captured.out
+
+    def test_init_refuses_existing_ow_toml(self, tmp_path, capsys):
+        (tmp_path / "ow.toml").write_text("[vars]")
+        with pytest.raises(SystemExit) as exc:
+            cmd_init(tmp_path)
+        assert exc.value.code == 1
+        captured = capsys.readouterr()
+        assert "existing files found" in captured.err.lower()
+        assert "ow.toml" in captured.err
+
+    def test_init_refuses_existing_templates(self, tmp_path, capsys):
+        tpl = tmp_path / "templates" / "common"
+        tpl.mkdir(parents=True)
+        (tpl / "dummy.txt").write_text("x")
+        with pytest.raises(SystemExit) as exc:
+            cmd_init(tmp_path)
+        assert exc.value.code == 1
+        captured = capsys.readouterr()
+        assert "templates/" in captured.err
+
+    def test_init_empty_dir_no_refuse(self, tmp_path, capsys):
+        tpl = tmp_path / "templates"
+        tpl.mkdir()
+        (tmp_path / "ow.toml").write_text("[vars]")
+        with pytest.raises(SystemExit) as exc:
+            cmd_init(tmp_path)
+        captured = capsys.readouterr()
+        assert "ow.toml" in captured.err
+        assert "templates/" not in captured.err
+
+    def test_init_existing_hint_about_force(self, tmp_path, capsys):
+        (tmp_path / "ow.toml").write_text("[vars]")
+        with pytest.raises(SystemExit) as exc:
+            cmd_init(tmp_path)
+        captured = capsys.readouterr()
+        assert "--force" in captured.err
+        assert "backup" in captured.err
+
+    def test_init_force_overwrites(self, tmp_path, capsys):
+        ow_toml = tmp_path / "ow.toml"
+        ow_toml.write_text("# old")
+        cmd_init(tmp_path, force=True)
+        captured = capsys.readouterr()
+        assert ow_toml.read_text() != "# old"
+        assert "Project initialized successfully" in captured.out
+
+    def test_init_force_with_backup(self, tmp_path, capsys):
+        ow_toml = tmp_path / "ow.toml"
+        ow_toml.write_text("# old ow")
+        mise_toml = tmp_path / "mise.toml"
+        mise_toml.write_text("# old mise")
+        tpl = tmp_path / "templates" / "common"
+        tpl.mkdir(parents=True)
+        (tpl / "dummy.txt").write_text("dummy")
+        svc = tmp_path / "services"
+        svc.mkdir()
+        cmd_init(tmp_path, with_backup=True)
+        captured = capsys.readouterr()
+        assert (tmp_path / "ow.toml.bak").exists()
+        assert (tmp_path / "mise.toml.bak").exists()
+        assert (tmp_path / "templates.bak").exists()
+        assert (tmp_path / "services.bak").exists()
+        assert "Backed up: ow.toml" in captured.out
+        assert "Backed up: mise.toml" in captured.out
+
+    def test_init_backup_removes_old_dir_backup(self, tmp_path):
+        ow_toml = tmp_path / "ow.toml"
+        ow_toml.write_text("# ow")
+        tpl = tmp_path / "templates" / "common"
+        tpl.mkdir(parents=True)
+        (tpl / "dummy.txt").write_text("dummy")
+        old_backup = tmp_path / "templates.bak"
+        old_backup.mkdir()
+        (old_backup / "old.txt").write_text("stale")
+        cmd_init(tmp_path, with_backup=True)
+        assert (old_backup / "common").exists()
+        assert not (old_backup / "old.txt").exists()
+
+    def test_init_backup_no_existing_files(self, tmp_path, capsys):
+        cmd_init(tmp_path, with_backup=True)
+        captured = capsys.readouterr()
+        assert "Backed up" not in captured.out
+        assert "Project initialized successfully" in captured.out

--- a/src/tests/commands/test_status_extended.py
+++ b/src/tests/commands/test_status_extended.py
@@ -1,0 +1,236 @@
+import re
+from pathlib import Path
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from ow.commands.status import (
+    _StatusResult,
+    _display_attached_status,
+    _display_detached_status,
+    _gather_repo_status,
+    _github_url_from_remote,
+    cmd_status,
+)
+from ow.utils.config import BranchSpec, Config, WorkspaceConfig, parse_branch_spec, write_workspace_config
+from ow.utils.config import RemoteConfig
+
+
+class TestGithubUrlFromRemote:
+    def test_ssh_url(self):
+        result = _github_url_from_remote("git@github.com:odoo/odoo.git")
+        assert result == "https://github.com/odoo/odoo"
+
+    def test_ssh_url_no_dotgit(self):
+        result = _github_url_from_remote("git@github.com:odoo/odoo")
+        assert result == "https://github.com/odoo/odoo"
+
+    def test_https_url(self):
+        result = _github_url_from_remote("https://github.com/odoo/odoo.git")
+        assert result == "https://github.com/odoo/odoo"
+
+    def test_https_url_no_dotgit(self):
+        result = _github_url_from_remote("https://github.com/odoo/odoo")
+        assert result == "https://github.com/odoo/odoo"
+
+    def test_gitlab_ssh_url_returns_none(self):
+        result = _github_url_from_remote("git@gitlab.com:odoo/odoo.git")
+        assert result is None
+
+    def test_unknown_format_returns_none(self):
+        result = _github_url_from_remote("https://gitlab.company.com/odoo/odoo.git")
+        assert result is None
+
+    def test_empty_string_returns_none(self):
+        result = _github_url_from_remote("")
+        assert result is None
+
+
+class TestDisplayDetachedStatus:
+    def test_detached_status_line(self, tmp_path):
+        worktree = tmp_path / "community"
+        worktree.mkdir()
+        spec = BranchSpec("origin/master")
+
+        with (
+            patch("ow.commands.status.get_rev_list_count", return_value=(2, 5)),
+            patch("ow.commands.status.get_worktree_head", return_value=("abcd123", "")),
+        ):
+            result = _display_detached_status("community", spec, spec, worktree, 9)
+
+        assert "community" in result
+        assert "DETACHED" in result
+        assert "abcd123" in result
+        assert "origin/master" in result
+
+
+class TestDisplayAttachedStatus:
+    def test_attached_with_remote_ref_found(self, tmp_path):
+        worktree = tmp_path / "community"
+        worktree.mkdir()
+        spec = BranchSpec("origin/master", "my-feature")
+        resolved = BranchSpec("origin/master", "my-feature")
+
+        with (
+            patch("ow.commands.status.get_remote_ref_for_branch", return_value="origin/my-feature"),
+            patch("ow.commands.status.get_rev_list_count") as mock_count,
+        ):
+            mock_count.side_effect = [(1, 3), (0, 2)]
+            result = _display_attached_status(
+                "community", spec, resolved, worktree, 9,
+                refs={"origin/my-feature"},
+            )
+
+        assert "community" in result
+        assert "origin/my-feature" in result
+        assert "origin/master" in result
+        assert mock_count.call_count == 2
+
+    def test_attached_with_upstream_not_base(self, tmp_path):
+        """When no remote ref but upstream exists and differs from base, show upstream + base."""
+        worktree = tmp_path / "community"
+        worktree.mkdir()
+        spec = BranchSpec("origin/master", "my-feature")
+        resolved = BranchSpec("origin/master", "my-feature")
+        with (
+            patch("ow.commands.status.get_remote_ref_for_branch", return_value=None),
+            patch("ow.commands.status.get_upstream", return_value="origin/my-feature"),
+            patch("ow.commands.status.get_rev_list_count") as mock_count,
+        ):
+            mock_count.side_effect = [(0, 1), (0, 2)]
+            result = _display_attached_status(
+                "community", spec, resolved, worktree, 9
+            )
+        assert "origin/my-feature" in result
+        assert "origin/master" in result
+        assert mock_count.call_count == 2
+
+    def test_attached_no_remote_ref_no_upstream(self, tmp_path):
+        worktree = tmp_path / "community"
+        worktree.mkdir()
+        spec = BranchSpec("origin/master", "my-feature")
+        resolved = BranchSpec("origin/master", "my-feature")
+
+        with (
+            patch("ow.commands.status.get_remote_ref_for_branch", return_value=None),
+            patch("ow.commands.status.get_upstream", return_value=None),
+            patch("ow.commands.status.get_rev_list_count", return_value=(0, 1)),
+        ):
+            result = _display_attached_status(
+                "community", spec, resolved, worktree, 9
+            )
+
+        assert "my-feature" in result
+        assert "(local)" in result
+        assert "origin/master" in result
+
+
+class TestGatherRepoStatus:
+    def test_gather_detached_with_github_link(self, tmp_path):
+        worktree = tmp_path / "community"
+        worktree.mkdir()
+        bare_repo = tmp_path / "community.git"
+        bare_repo.mkdir()
+        spec = BranchSpec("origin/master")
+
+        with (
+            patch("ow.commands.status.get_rev_list_count", return_value=(0, 0)),
+            patch("ow.commands.status.get_worktree_head", return_value=("abc123", "")),
+            patch("ow.commands.status.get_remote_url", return_value="git@github.com:odoo/odoo.git"),
+        ):
+            result = _gather_repo_status(
+                "community", spec, spec, worktree, bare_repo, 9, set()
+            )
+
+        assert isinstance(result, _StatusResult)
+        assert "DETACHED" in result.status_line
+        assert result.first_attached_branch is None
+        assert result.github_link is not None
+        assert result.github_link[0] == "community"
+        assert "github.com" in result.github_link[1]
+
+    def test_gather_attached_branch(self, tmp_path):
+        worktree = tmp_path / "community"
+        worktree.mkdir()
+        bare_repo = tmp_path / "community.git"
+        bare_repo.mkdir()
+        spec = BranchSpec("origin/master", "feature")
+        resolved = BranchSpec("origin/master", "feature")
+
+        with (
+            patch("ow.commands.status.get_remote_ref_for_branch", return_value=None),
+            patch("ow.commands.status.get_upstream", return_value=None),
+            patch("ow.commands.status.get_rev_list_count", return_value=(0, 0)),
+            patch("ow.commands.status.get_remote_url", return_value="git@github.com:odoo/odoo.git"),
+        ):
+            result = _gather_repo_status(
+                "community", spec, resolved, worktree, bare_repo, 9, set()
+            )
+
+        assert isinstance(result, _StatusResult)
+        assert result.first_attached_branch == "feature"
+        assert result.github_link is not None
+        assert "tree/feature" in result.github_link[1]
+
+    def test_gather_non_github_remote(self, tmp_path):
+        worktree = tmp_path / "community"
+        worktree.mkdir()
+        bare_repo = tmp_path / "community.git"
+        bare_repo.mkdir()
+        spec = BranchSpec("origin/master")
+
+        with (
+            patch("ow.commands.status.get_rev_list_count", return_value=(0, 0)),
+            patch("ow.commands.status.get_worktree_head", return_value=("abc", "")),
+            patch("ow.commands.status.get_remote_url", return_value="https://gitlab.server.com/odoo.git"),
+        ):
+            result = _gather_repo_status(
+                "community", spec, spec, worktree, bare_repo, 9, set()
+            )
+
+        assert result.github_link is None
+
+    def test_gather_no_remote_url(self, tmp_path):
+        worktree = tmp_path / "community"
+        worktree.mkdir()
+        bare_repo = tmp_path / "community.git"
+        bare_repo.mkdir()
+        spec = BranchSpec("origin/master")
+
+        with (
+            patch("ow.commands.status.get_rev_list_count", return_value=(0, 0)),
+            patch("ow.commands.status.get_worktree_head", return_value=("abc", "")),
+            patch("ow.commands.status.get_remote_url", return_value=None),
+        ):
+            result = _gather_repo_status(
+                "community", spec, spec, worktree, bare_repo, 9, set()
+            )
+
+        assert result.github_link is None
+
+
+class TestCmdStatusExtended:
+    def test_cmd_status_no_worktrees(self, tmp_path, capsys, config):
+        ws_dir = tmp_path / "workspaces" / "test"
+        ws_dir.mkdir(parents=True)
+        ws = WorkspaceConfig(
+            repos={"community": BranchSpec("origin/master")},
+            templates=["common"],
+        )
+        write_workspace_config(ws_dir / ".ow" / "config", ws)
+
+        with (
+            patch.dict("os.environ", {"OW_WORKSPACE": str(ws_dir)}),
+            patch("ow.commands.status.fetch_workspace_refs", return_value=({"community": "origin/master"}, {}, {})),
+            patch("ow.commands.status.warn_if_drifted"),
+        ):
+            cmd_status(config)
+
+        captured = capsys.readouterr()
+        assert "test" in captured.out
+        assert "(not applied)" in captured.out
+
+
+def _mock_parallel_exec(tasks):
+    return {k: fn() for k, fn in tasks.items()}

--- a/src/tests/utils/test_templates_extended.py
+++ b/src/tests/utils/test_templates_extended.py
@@ -1,0 +1,219 @@
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from ow.utils.config import BranchSpec, Config, WorkspaceConfig
+from ow.utils.templates import (
+    _get_packaged_templates,
+    _resolve_template_dir,
+    available_templates,
+    apply_templates,
+    ensure_workspace_materialized,
+    is_odoo_main_repo,
+)
+
+
+class TestGetPackagedTemplates:
+    def test_returns_template_names(self):
+        names = _get_packaged_templates()
+        assert "common" in names
+        assert "vscode" in names
+        assert "zed" in names
+
+
+class TestAvailableTemplates:
+    def test_returns_packaged_only(self, tmp_path):
+        config = Config(vars={}, remotes={}, root_dir=tmp_path)
+        names = available_templates(config)
+        assert "common" in names
+        assert "vscode" in names
+
+    def test_merges_local_and_packaged(self, tmp_path):
+        local = tmp_path / "templates" / "my-custom"
+        local.mkdir(parents=True)
+        config = Config(vars={}, remotes={}, root_dir=tmp_path)
+        names = available_templates(config)
+        assert "my-custom" in names
+        assert "common" in names
+        assert "vscode" in names
+
+    def test_sorted_order(self, tmp_path):
+        for name in ["my-custom"]:
+            d = tmp_path / "templates" / name
+            d.mkdir(parents=True)
+        config = Config(vars={}, remotes={}, root_dir=tmp_path)
+        names = available_templates(config)
+        assert names == sorted(names)
+
+
+class TestResolveTemplateDir:
+    def test_packaged_template(self, tmp_path):
+        config = Config(vars={}, remotes={}, root_dir=tmp_path)
+        result = _resolve_template_dir("common", config)
+        assert result.is_dir()
+
+    def test_local_template_takes_priority(self, tmp_path):
+        local = tmp_path / "templates" / "common"
+        local.mkdir(parents=True)
+        (local / "custom.txt").write_text("local")
+        config = Config(vars={}, remotes={}, root_dir=tmp_path)
+        result = _resolve_template_dir("common", config)
+        assert result == local
+
+    def test_missing_template_raises(self, tmp_path):
+        config = Config(vars={}, remotes={}, root_dir=tmp_path)
+        with pytest.raises(FileNotFoundError, match="not found"):
+            _resolve_template_dir("nonexistent-template", config)
+
+
+class TestIsOdooMainRepo:
+    def test_true(self, tmp_path):
+        repo = tmp_path / "community"
+        repo.mkdir(parents=True)
+        (repo / "odoo-bin").touch()
+        (repo / "addons").mkdir(parents=True)
+        (repo / "odoo" / "addons").mkdir(parents=True)
+        assert is_odoo_main_repo(repo) is True
+
+    def test_false_no_odoo_bin(self, tmp_path):
+        repo = tmp_path / "enterprise"
+        (repo / "addons").mkdir(parents=True)
+        assert is_odoo_main_repo(repo) is False
+
+    def test_false_no_addons(self, tmp_path):
+        repo = tmp_path / "odoo"
+        repo.mkdir(parents=True)
+        (repo / "odoo-bin").touch()
+        assert is_odoo_main_repo(repo) is False
+
+
+class TestApplyTemplates:
+    def _make_main_repo(self, ws_dir):
+        repo = ws_dir / "community"
+        repo.mkdir()
+        (repo / "odoo-bin").touch()
+        (repo / "addons").mkdir(parents=True)
+        (repo / "odoo" / "addons").mkdir(parents=True)
+
+    def test_applies_common_to_workspace(self, tmp_path, config):
+        ws_dir = tmp_path / "workspaces" / "test"
+        ws_dir.mkdir(parents=True)
+        ws = WorkspaceConfig(repos={}, templates=["common"])
+        apply_templates(ws, config, ws_dir)
+
+        assert (ws_dir / "odoorc").exists()
+        assert (ws_dir / "pyrightconfig.json").exists()
+        assert (ws_dir / "requirements-dev.txt").exists()
+
+    def test_template_uses_context(self, tmp_path, config):
+        ws_dir = tmp_path / "workspaces" / "my-test-ws"
+        ws_dir.mkdir(parents=True)
+        ws = WorkspaceConfig(repos={}, templates=["common"])
+        apply_templates(ws, config, ws_dir)
+        odoorc = (ws_dir / "odoorc").read_text()
+        assert "my-test-ws" in odoorc
+
+    def test_applies_with_main_repo_context(self, tmp_path, config):
+        ws_dir = tmp_path / "workspaces" / "test"
+        ws_dir.mkdir(parents=True)
+        self._make_main_repo(ws_dir)
+        ws = WorkspaceConfig(repos={"community": BranchSpec("origin/master")}, templates=["common"])
+        apply_templates(ws, config, ws_dir)
+        odoorc = (ws_dir / "odoorc").read_text()
+        assert "community/addons" in odoorc
+
+    def test_applies_vscode(self, tmp_path, config):
+        ws_dir = tmp_path / "workspaces" / "test"
+        ws_dir.mkdir(parents=True)
+        self._make_main_repo(ws_dir)
+        ws = WorkspaceConfig(repos={"community": BranchSpec("origin/master")}, templates=["common", "vscode"])
+        apply_templates(ws, config, ws_dir)
+        assert (ws_dir / ".vscode" / "settings.json").exists()
+        assert (ws_dir / ".vscode" / "launch.json").exists()
+
+    def test_later_template_overrides_earlier(self, tmp_path, config):
+        ws_dir = tmp_path / "workspaces" / "test"
+        ws_dir.mkdir(parents=True)
+        self._make_main_repo(ws_dir)
+        ws = WorkspaceConfig(repos={"community": BranchSpec("origin/master")}, templates=["common", "vscode"])
+        apply_templates(ws, config, ws_dir)
+        assert (ws_dir / "odoorc").exists()
+
+
+class TestEnsureWorkspaceMaterialized:
+    def test_no_repos_returns_empty(self, tmp_path, config_with_remotes):
+        ws_dir = tmp_path / "workspaces" / "test"
+        config = config_with_remotes
+        ws = WorkspaceConfig(repos={}, templates=["common"])
+        result_dir, successful, errors = ensure_workspace_materialized(ws, config, ws_dir)
+        assert result_dir == ws_dir
+        assert successful == set()
+        assert errors == {}
+
+    def test_attaches_detached_worktree(self, tmp_path, config_with_remotes):
+        ws_dir = tmp_path / "workspaces" / "test"
+        ws_dir.mkdir(parents=True)
+        config = config_with_remotes
+        ws = WorkspaceConfig(repos={"community": BranchSpec("origin/master", "my-feature")}, templates=["common"])
+
+        with patch("ow.utils.templates.ensure_bare_repo"):
+            with patch("ow.utils.templates.resolve_spec") as mock_resolve:
+                mock_resolve.return_value = BranchSpec("origin/master", "my-feature")
+                with patch("ow.utils.templates.parallel_per_repo", return_value={"community": BranchSpec("origin/master", "my-feature")}):
+                    with patch("ow.utils.templates.worktree_exists", return_value=True):
+                        with patch("ow.utils.templates.worktree_is_detached", return_value=True):
+                            with patch("ow.utils.templates.attach_worktree") as mock_attach:
+                                with patch("ow.utils.templates.run_cmd"):
+                                    ensure_workspace_materialized(ws, config, ws_dir)
+        mock_attach.assert_called_once()
+
+    def test_detaches_attached_worktree(self, tmp_path, config_with_remotes):
+        ws_dir = tmp_path / "workspaces" / "test"
+        ws_dir.mkdir(parents=True)
+        config = config_with_remotes
+        ws = WorkspaceConfig(repos={"community": BranchSpec("origin/master")}, templates=["common"])
+
+        with patch("ow.utils.templates.ensure_bare_repo"):
+            with patch("ow.utils.templates.resolve_spec") as mock_resolve:
+                mock_resolve.return_value = BranchSpec("origin/master")
+                with patch("ow.utils.templates.parallel_per_repo", return_value={"community": BranchSpec("origin/master")}):
+                    with patch("ow.utils.templates.worktree_exists", return_value=True):
+                        with patch("ow.utils.templates.worktree_is_detached", return_value=False):
+                            with patch("ow.utils.templates.detach_worktree") as mock_detach:
+                                with patch("ow.utils.templates.run_cmd"):
+                                    ensure_workspace_materialized(ws, config, ws_dir)
+        mock_detach.assert_called_once()
+
+    def test_sets_upstream_when_attached(self, tmp_path, config_with_remotes):
+        ws_dir = tmp_path / "workspaces" / "test"
+        ws_dir.mkdir(parents=True)
+        config = config_with_remotes
+        ws = WorkspaceConfig(repos={"community": BranchSpec("origin/master", "my-feature")}, templates=["common"])
+
+        with patch("ow.utils.templates.ensure_bare_repo"):
+            with patch("ow.utils.templates.resolve_spec") as mock_resolve:
+                mock_resolve.return_value = BranchSpec("origin/master", "my-feature")
+                with patch("ow.utils.templates.parallel_per_repo", return_value={"community": BranchSpec("origin/master", "my-feature")}):
+                    with patch("ow.utils.templates.worktree_exists", return_value=True):
+                        with patch("ow.utils.templates.worktree_is_detached", return_value=False):
+                            with patch("ow.utils.templates.set_branch_upstream") as mock_upstream:
+                                with patch("ow.utils.templates.run_cmd"):
+                                    ensure_workspace_materialized(ws, config, ws_dir)
+        mock_upstream.assert_called_once()
+
+    def test_creates_new_worktree(self, tmp_path, config_with_remotes):
+        ws_dir = tmp_path / "workspaces" / "test"
+        ws_dir.mkdir(parents=True)
+        config = config_with_remotes
+        ws = WorkspaceConfig(repos={"community": BranchSpec("origin/master")}, templates=["common"])
+
+        with patch("ow.utils.templates.ensure_bare_repo"):
+            with patch("ow.utils.templates.resolve_spec") as mock_resolve:
+                mock_resolve.return_value = BranchSpec("origin/master")
+                with patch("ow.utils.templates.parallel_per_repo", return_value={"community": BranchSpec("origin/master")}):
+                    with patch("ow.utils.templates.worktree_exists", return_value=False):
+                        with patch("ow.utils.templates.run_cmd"):
+                            with patch("ow.utils.templates.create_worktree") as mock_create:
+                                ensure_workspace_materialized(ws, config, ws_dir)
+        mock_create.assert_called_once()


### PR DESCRIPTION
# Coverage: 76% → 89%

## Changes

Added 3 new test files with 56 tests total:

### `src/tests/commands/test_init.py` — 20 tests
- `_copy_packaged_templates` — copies dirs, nested files, overwrites existing
- `_copy_ow_services` — copies services, idempotent
- `cmd_init` — creates files, default path, content checks, existing file refusal, force overwrite, backup paths

### `src/tests/commands/test_status_extended.py` — 16 tests
- `_github_url_from_remote` — SSH, HTTPS, non-GitHub, edge cases
- `_display_detached_status` — format verification
- `_display_attached_status` — remote ref found, upstream ≠ base, pure local fallback
- `_gather_repo_status` — detached GitHub link, attached branch, non-GitHub remote
- `cmd_status` — no worktrees integration test

### `src/tests/utils/test_templates_extended.py` — 20 tests
- `_get_packaged_templates` — returns names
- `available_templates` — packaged only, merges local, sorted
- `_resolve_template_dir` — packaged, local priority, missing raises
- `is_odoo_main_repo` — true, false cases
- `apply_templates` — common rendering, context variables, multiple templates
- `ensure_workspace_materialized` — empty repos, attach/detach worktree, set upstream, create

## Coverage Impact

| Module | Before | After |
|---|---|---|
| commands/init.py | 7% | 98% |
| commands/status.py | 50% | 91% |
| utils/templates.py | 44% | 92% |
| **TOTAL** | **76%** | **89%** |