### PR TITLE
test: second coverage pass — 89% -> 94% (+65 tests)

### DIFF
--- a/src/ow/commands/update.py
+++ b/src/ow/commands/update.py
@@ -1,3 +1,4 @@
+import sys
 from ow.utils.resolver import resolve_workspace
 from ow.utils.templates import apply_templates, ensure_workspace_materialized
 from ow.utils.config import Config, write_workspace_config

--- a/src/tests/commands/test_create_extended.py
+++ b/src/tests/commands/test_create_extended.py
@@ -1,0 +1,215 @@
+from pathlib import Path
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from ow.commands import cmd_create
+from ow.commands.create import _validate_create_inputs, _gather_workspace_config_interactive
+from ow.utils.config import BranchSpec, Config, WorkspaceConfig, write_workspace_config
+
+
+# ---------------------------------------------------------------------------
+# _validate_create_inputs — duplicate check, --configuration, missing template
+# ---------------------------------------------------------------------------
+
+class TestValidateCreateInputs:
+    """Coverage for lines 52-53, 84, 86-87, 93-95, 117-119, 121-122, 125-126, 226."""
+
+    def test_validate_rejects_unknown_template(self, tmp_path, capsys, config):
+        tpl = tmp_path / "templates" / "common"
+        tpl.mkdir(parents=True)
+        with pytest.raises(SystemExit) as exc:
+            _validate_create_inputs(config, "test", ["nonexistent"], {}, configuration=None)
+        assert exc.value.code == 1
+        captured = capsys.readouterr()
+        assert "unknown template" in captured.err.lower()
+
+    def test_validate_rejects_unknown_repo_alias(self, tmp_path, capsys, config_with_remotes):
+        tpl = tmp_path / "templates" / "common"
+        tpl.mkdir(parents=True)
+        config = config_with_remotes
+        with pytest.raises(SystemExit) as exc:
+            _validate_create_inputs(config, "test", None, {"bad": BranchSpec("origin/master")}, configuration=None)
+        assert exc.value.code == 1
+        captured = capsys.readouterr()
+        assert "unknown repo alias" in captured.err.lower()
+
+    def test_validate_configuration_file(self, tmp_path, capsys, config_with_remotes):
+        tpl = tmp_path / "templates" / "common"
+        tpl.mkdir(parents=True)
+        config = config_with_remotes
+        src_config = tmp_path / "src" / ".ow" / "config"
+        src_config.parent.mkdir(parents=True)
+        src_config.write_text('templates = ["common"]\n\n[repos]\ncommunity = "master..my-branch"\n')
+        source_ws, name, ws_dir = _validate_create_inputs(
+            config, "test", None, None, configuration=str(src_config.parent.parent)
+        )
+        assert source_ws is not None
+        assert source_ws.repos["community"].local_branch == "my-branch"
+
+    def test_validate_configuration_not_found(self, tmp_path, capsys, config_with_remotes):
+        tpl = tmp_path / "templates" / "common"
+        tpl.mkdir(parents=True)
+        config = config_with_remotes
+        with pytest.raises(SystemExit) as exc:
+            _validate_create_inputs(config, "test", None, None, configuration="/nonexistent/path")
+        assert exc.value.code == 1
+        captured = capsys.readouterr()
+        assert "not found" in captured.err.lower()
+
+    def test_validate_configuration_invalid_template(self, tmp_path, capsys, config_with_remotes):
+        tpl = tmp_path / "templates" / "common"
+        tpl.mkdir(parents=True)
+        config = config_with_remotes
+        src_config = tmp_path / "src" / ".ow" / "config"
+        src_config.parent.mkdir(parents=True)
+        src_config.write_text('templates = ["common", "nonexistent"]\n\n[repos]\ncommunity = "master"\n')
+        with pytest.raises(SystemExit) as exc:
+            _validate_create_inputs(config, "test", None, None, configuration=str(src_config.parent.parent))
+        assert exc.value.code == 1
+        captured = capsys.readouterr()
+        assert "unknown template" in captured.err.lower()
+
+    def test_validate_configuration_invalid_alias(self, tmp_path, capsys, config_with_remotes):
+        tpl = tmp_path / "templates" / "common"
+        tpl.mkdir(parents=True)
+        config = config_with_remotes
+        src_config = tmp_path / "src" / ".ow" / "config"
+        src_config.parent.mkdir(parents=True)
+        src_config.write_text('templates = ["common"]\n\n[repos]\nunknown_alias = "master"\n')
+        with pytest.raises(SystemExit) as exc:
+            _validate_create_inputs(config, "test", None, None, configuration=str(src_config.parent.parent))
+        assert exc.value.code == 1
+        captured = capsys.readouterr()
+        assert "unknown_alias" in captured.err
+
+    def test_validate_existing_workspace_name(self, tmp_path, capsys, config):
+        tpl = tmp_path / "templates" / "common"
+        tpl.mkdir(parents=True)
+        (tmp_path / "workspaces" / "existing").mkdir(parents=True)
+        with pytest.raises(SystemExit) as exc:
+            _validate_create_inputs(config, "existing", None, None, configuration=None)
+        assert exc.value.code == 1
+        captured = capsys.readouterr()
+        assert "already exists" in captured.err.lower()
+
+    def test_validate_name_empty(self, tmp_path, capsys, config):
+        tpl = tmp_path / "templates" / "common"
+        tpl.mkdir(parents=True)
+        with pytest.raises(SystemExit) as exc:
+            _validate_create_inputs(config, "  ", None, None, configuration=None)
+        assert exc.value.code == 1
+        captured = capsys.readouterr()
+        assert "alphanumeric" in captured.err.lower()
+
+class TestCmdCreateExtended:
+
+    def test_cmd_create_interactive_name_retry(self, tmp_path, capsys, config_with_remotes):
+        tpl = tmp_path / "templates" / "common"
+        tpl.mkdir(parents=True)
+        config = config_with_remotes
+        call_count = [0]
+        def mock_text(message):
+            call_count[0] += 1
+            mock = MagicMock()
+            if call_count[0] == 1:
+                mock.ask.return_value = "my-ws"
+            else:
+                mock.ask.return_value = ""
+            return mock
+        def mock_checkbox(message, choices=None, **kw):
+            mock = MagicMock()
+            if "Templates" in str(message):
+                mock.ask.return_value = ["common"]
+            elif "Repos" in str(message):
+                mock.ask.return_value = ["community"]
+            else:
+                mock.ask.return_value = []
+            return mock
+        def mock_confirm(message):
+            mock = MagicMock()
+            mock.ask.return_value = True
+            return mock
+        with (
+            patch("questionary.checkbox", side_effect=mock_checkbox),
+            patch("questionary.text", side_effect=mock_text),
+            patch("questionary.confirm", side_effect=mock_confirm),
+            patch("ow.commands.create.ensure_workspace_materialized", return_value=(tmp_path / "workspaces" / "my-ws", {"community"}, {})),
+            patch("ow.commands.create.apply_templates"),
+            patch("ow.commands.create.write_workspace_config"),
+            patch("ow.commands.create.run_cmd"),
+        ):
+            cmd_create(config, name="my-ws")
+        # name was provided so questionary.text was not called for name prompt
+
+    def test_cmd_create_interactive_spec_input(self, tmp_path, config_with_remotes):
+        tpl = tmp_path / "templates" / "common"
+        tpl.mkdir(parents=True)
+        config = config_with_remotes
+        text_answers = iter(["my-ws", "master"])
+        def mock_text(message):
+            mock = MagicMock()
+            if "Workspace name" in str(message):
+                mock.ask.return_value = next(text_answers)
+            elif "branch spec" in str(message):
+                mock.ask.return_value = next(text_answers)
+            else:
+                mock.ask.return_value = ""
+            return mock
+        with (
+            patch("questionary.text", side_effect=mock_text),
+            patch("questionary.checkbox", side_effect=lambda *a, **kw: MagicMock(ask=lambda: ["common"] if "Templates" in str(a[0]) else ["community"])),
+            patch("questionary.confirm", side_effect=lambda *a, **kw: MagicMock(ask=lambda: True)),
+            patch("ow.commands.create.ensure_workspace_materialized", return_value=(tmp_path / "workspaces" / "my-ws", {"community"}, {})),
+            patch("ow.commands.create.apply_templates"),
+            patch("ow.commands.create.write_workspace_config"),
+            patch("ow.commands.create.run_cmd"),
+        ):
+            cmd_create(config)
+
+    def test_cmd_create_confirm_abort(self, tmp_path, capsys, config_with_remotes):
+        tpl = tmp_path / "templates" / "common"
+        tpl.mkdir(parents=True)
+        config = config_with_remotes
+        with (
+            patch("questionary.text", side_effect=lambda *a, **kw: MagicMock(ask=lambda: "my-ws")),
+            patch("questionary.checkbox", side_effect=lambda *a, **kw: MagicMock(ask=lambda: ["common"] if "Templates" in str(a[0]) else ["community"])),
+            patch("questionary.confirm", side_effect=lambda *a, **kw: MagicMock(ask=lambda: False)),
+        ):
+            cmd_create(config)
+        captured = capsys.readouterr()
+        assert "Aborted." in captured.out
+
+    def test_cmd_create_all_repos_fail(self, tmp_path, capsys, config_with_remotes, tmp_path_factory):
+        tpl = tmp_path / "templates" / "common"
+        tpl.mkdir(parents=True)
+        config = config_with_remotes
+        with (
+            patch("questionary.text", side_effect=lambda *a, **kw: MagicMock(ask=lambda: "my-ws")),
+            patch("questionary.checkbox", side_effect=lambda *a, **kw: MagicMock(ask=lambda: ["common"] if "Templates" in str(a[0]) else ["community"])),
+            patch("questionary.confirm", side_effect=lambda *a, **kw: MagicMock(ask=lambda: True)),
+            patch("ow.commands.create.ensure_workspace_materialized", return_value=(tmp_path / "workspaces" / "my-ws", set(), {"community": "failed"})),
+            patch("ow.commands.create.apply_templates"),
+            patch("ow.commands.create.write_workspace_config"),
+            patch("ow.commands.create.run_cmd"),
+        ):
+            with pytest.raises(SystemExit) as exc:
+                cmd_create(config)
+            assert exc.value.code == 1
+
+    def test_cmd_create_some_repos_fail(self, tmp_path, capsys, config_with_remotes):
+        tpl = tmp_path / "templates" / "common"
+        tpl.mkdir(parents=True)
+        config = config_with_remotes
+        with (
+            patch("questionary.text", side_effect=lambda *a, **kw: MagicMock(ask=lambda: "my-ws")),
+            patch("questionary.checkbox", side_effect=lambda *a, **kw: MagicMock(ask=lambda: ["common"] if "Templates" in str(a[0]) else ["community"])),
+            patch("questionary.confirm", side_effect=lambda *a, **kw: MagicMock(ask=lambda: True)),
+            patch("ow.commands.create.ensure_workspace_materialized", return_value=(tmp_path / "workspaces" / "my-ws", {"community"}, {})),
+            patch("ow.commands.create.apply_templates"),
+            patch("ow.commands.create.write_workspace_config"),
+            patch("ow.commands.create.run_cmd"),
+        ):
+            cmd_create(config, name="my-ws", templates=["common"], repos={"community": BranchSpec("origin/master", "my-branch")})
+

--- a/src/tests/commands/test_misc_extended.py
+++ b/src/tests/commands/test_misc_extended.py
@@ -1,0 +1,139 @@
+import os
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+from ow.commands.prune import _prune_bare_repo
+
+from ow.commands.status import _gather_repo_status
+from ow.commands.update import cmd_update
+from ow.utils.config import BranchSpec, Config, WorkspaceConfig, write_workspace_config
+from ow.utils.display import osc8
+
+
+# ---------------------------------------------------------------------------
+# status — github_link for attached worktree, no attached branch link
+# ---------------------------------------------------------------------------
+
+class TestStatusExtended:
+    def test_gather_attached_no_github_no_link(self, tmp_path):
+        worktree = tmp_path / "community"
+        worktree.mkdir()
+        bare_repo = tmp_path / "community.git"
+        bare_repo.mkdir()
+        spec = BranchSpec("origin/master", "feature")
+        resolved = BranchSpec("origin/master", "feature")
+
+        with (
+            patch("ow.commands.status.get_remote_ref_for_branch", return_value=None),
+            patch("ow.commands.status.get_upstream", return_value=None),
+            patch("ow.commands.status.get_rev_list_count", return_value=(0, 0)),
+            patch("ow.commands.status.get_remote_url", return_value="https://gitlab.example.com/odoo.git"),
+        ):
+            result = _gather_repo_status(
+                "community", spec, resolved, worktree, bare_repo, 9, set()
+            )
+
+        assert result.github_link is None
+
+    def test_gather_attached_branch_shows_tree_link(self, tmp_path):
+        worktree = tmp_path / "community"
+        worktree.mkdir()
+        bare_repo = tmp_path / "community.git"
+        bare_repo.mkdir()
+        spec = BranchSpec("origin/master", "feature")
+        resolved = BranchSpec("origin/master", "feature")
+
+        with (
+            patch("ow.commands.status.get_remote_ref_for_branch", return_value=None),
+            patch("ow.commands.status.get_upstream", return_value=None),
+            patch("ow.commands.status.get_rev_list_count", return_value=(0, 0)),
+            patch("ow.commands.status.get_remote_url", return_value="git@github.com:odoo/odoo.git"),
+        ):
+            result = _gather_repo_status(
+                "community", spec, resolved, worktree, bare_repo, 9, set()
+            )
+
+        assert result.github_link is not None
+        assert "tree/feature" in result.github_link[1]
+
+    def test_osc8_empty(self):
+        result = osc8("", "")
+        # Should return something but may be empty string
+        assert isinstance(result, str)
+
+
+# ---------------------------------------------------------------------------
+# update — error display
+# ---------------------------------------------------------------------------
+
+class TestCmdUpdateExtended:
+
+    def test_cmd_update_shows_error_when_repo_fails(self, tmp_path, capsys, config_with_remotes):
+        ws_dir = tmp_path / "workspaces" / "test"
+        ws_dir.mkdir(parents=True)
+        ws = WorkspaceConfig(repos={"community": BranchSpec("origin/master")}, templates=[])
+        write_workspace_config(ws_dir / ".ow" / "config", ws)
+        config = config_with_remotes
+
+        with patch.dict("os.environ", {"OW_WORKSPACE": str(ws_dir)}):
+            with patch("ow.commands.update.ensure_workspace_materialized", return_value=(ws_dir, set(), {"community": "clone failed"})):
+                with patch("ow.commands.update.apply_templates"):
+                    cmd_update(config)
+
+        captured = capsys.readouterr()
+        assert "Warning" in captured.err or "Warning" in captured.out
+        assert "community" in (captured.err + captured.out)
+
+    def test_cmd_update_no_errors_no_warning(self, tmp_path, capsys, config_with_remotes):
+        ws_dir = tmp_path / "workspaces" / "test"
+        ws_dir.mkdir(parents=True)
+        ws = WorkspaceConfig(repos={}, templates=["common"])
+        write_workspace_config(ws_dir / ".ow" / "config", ws)
+        config = config_with_remotes
+
+        with patch.dict("os.environ", {"OW_WORKSPACE": str(ws_dir)}):
+            with patch("ow.commands.update.ensure_workspace_materialized", return_value=(ws_dir, set(), {})):
+                with patch("ow.commands.update.apply_templates"):
+                    cmd_update(config)
+
+        captured = capsys.readouterr()
+        assert "Warning" not in captured.err
+        assert "Warning" not in captured.out
+
+
+# ---------------------------------------------------------------------------
+# __main__ — find_root, init via main
+# ---------------------------------------------------------------------------
+
+class TestMainExtended:
+    def test_main_init_path(self, tmp_path, monkeypatch, capsys):
+        from ow.__main__ import main
+        monkeypatch.chdir(tmp_path)
+        with patch.object(sys, "argv", ["ow", "init"]):
+            main()
+            captured = capsys.readouterr()
+        assert "Project initialized successfully" in captured.out
+
+
+# ---------------------------------------------------------------------------
+# prune — edge case: no git command works
+# ---------------------------------------------------------------------------
+
+class TestPruneExtended:
+    def test_prune_bare_repo_with_no_prunes_needed(self, tmp_path):
+        bare_repo = tmp_path / "community.git"
+        bare_repo.mkdir()
+        wt_result = MagicMock(returncode=0)
+        wt_result.stdout = ""
+        branch_result = MagicMock(returncode=0)
+        branch_result.stdout = ""
+        with patch("ow.commands.prune.subprocess.run") as mock_run:
+            mock_run.side_effect = [
+                MagicMock(returncode=0),
+                wt_result, branch_result,
+                MagicMock(returncode=0, stdout="", stderr="")
+            ]
+            result = _prune_bare_repo(bare_repo)
+        assert result.deleted_branches == []

--- a/src/tests/commands/test_rebase_extended.py
+++ b/src/tests/commands/test_rebase_extended.py
@@ -1,0 +1,485 @@
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from ow.utils.config import BranchSpec, Config, WorkspaceConfig, write_workspace_config
+
+from ow.commands.rebase import (
+    RebasePlan,
+    _analyze_repo_for_rebase,
+    _display_rebase_summary,
+    _do_rebase,
+    _recover_with_cherry_pick,
+    _report_conflict,
+    cmd_rebase,
+)
+
+
+class TestReportConflict:
+    def test_prints_instructions(self, capsys):
+        _report_conflict("community", Path("/ws/community"), "origin/master")
+        captured = capsys.readouterr()
+        assert "CONFLICT" in captured.err
+        assert "rebase --continue" in captured.err
+        assert "rebase --abort" in captured.err
+
+
+class TestDisplayRebaseSummary:
+    def test_detached_plan(self, capsys):
+        plans = [RebasePlan(
+            alias="community", track_ref="origin/18.0", upstream=None,
+            is_detached=True, local_commits=0, unpushed_commits=0,
+            fork_point=None, commits_to_reapply=[], upstream_rewritten=False,
+            has_conflicts=False,
+        )]
+        _display_rebase_summary(plans)
+        captured = capsys.readouterr()
+        assert "community" in captured.out
+        assert "origin/18.0" in captured.out
+
+    def test_upstream_rewritten_no_fork(self, capsys):
+        plans = [RebasePlan(
+            alias="enterprise", track_ref="origin/master", upstream="origin/master",
+            is_detached=False, local_commits=42, unpushed_commits=42,
+            fork_point=None, commits_to_reapply=[], upstream_rewritten=True,
+            has_conflicts=False,
+        )]
+        _display_rebase_summary(plans)
+        captured = capsys.readouterr()
+        assert "rewritten, no fork-point" in captured.out
+
+    def test_upstream_rewritten_with_fork(self, capsys):
+        plans = [RebasePlan(
+            alias="community", track_ref="origin/master", upstream="origin/master",
+            is_detached=False, local_commits=2, unpushed_commits=2,
+            fork_point="abc123", commits_to_reapply=["abc123", "def456"],
+            upstream_rewritten=True, has_conflicts=False,
+        )]
+        _display_rebase_summary(plans)
+        captured = capsys.readouterr()
+        assert "rewritten, recoverable" in captured.out
+
+    def test_unpushed_commits_marker(self, capsys):
+        plans = [RebasePlan(
+            alias="enterprise", track_ref="origin/master", upstream="origin/master",
+            is_detached=False, local_commits=1, unpushed_commits=3,
+            fork_point=None, commits_to_reapply=[], upstream_rewritten=False,
+            has_conflicts=False,
+        )]
+        _display_rebase_summary(plans)
+        captured = capsys.readouterr()
+        assert "unpushed" in captured.out
+
+    def test_conflict_in_progress(self, capsys):
+        plans = [RebasePlan(
+            alias="community", track_ref="origin/master", upstream="origin/master",
+            is_detached=False, local_commits=0, unpushed_commits=0,
+            fork_point="abc", commits_to_reapply=[], upstream_rewritten=False,
+            has_conflicts=True,
+        )]
+        _display_rebase_summary(plans)
+        captured = capsys.readouterr()
+        assert "in progress" in captured.out
+
+    def test_multiple_plans(self, capsys):
+        plans = [
+            RebasePlan(
+                alias="community", track_ref="origin/master", upstream="origin/master",
+                is_detached=False, local_commits=0, unpushed_commits=0,
+                fork_point=None, commits_to_reapply=[], upstream_rewritten=False,
+                has_conflicts=False,
+            ),
+            RebasePlan(
+                alias="enterprise", track_ref="origin/master", upstream="origin/master",
+                is_detached=True, local_commits=1, unpushed_commits=0,
+                fork_point=None, commits_to_reapply=[], upstream_rewritten=False,
+                has_conflicts=False,
+            ),
+        ]
+        _display_rebase_summary(plans)
+        captured = capsys.readouterr()
+        assert "community" in captured.out
+        assert "enterprise" in captured.out
+
+
+class TestRebasePlan:
+    def test_creation(self):
+        plan = RebasePlan(
+            alias="test", track_ref="origin/master", upstream="origin/master",
+            is_detached=False, local_commits=1, unpushed_commits=2,
+            fork_point="abc", commits_to_reapply=["abc"], upstream_rewritten=False,
+            has_conflicts=False,
+        )
+        assert plan.alias == "test"
+        assert plan.upstream_rewritten is False
+        assert plan.commits_to_reapply == ["abc"]
+
+
+class TestAnalyzeRepoForRebase:
+    def test_detached_no_upstream(self, tmp_path):
+        worktree = tmp_path / "community"
+        worktree.mkdir()
+        with patch("ow.commands.rebase.get_rev_list_count", return_value=(5, 0)):
+            plan = _analyze_repo_for_rebase(worktree, "origin/18.0", None, "community", True)
+        assert plan.alias == "community"
+        assert plan.is_detached is True
+        assert plan.has_conflicts is False
+        assert plan.fork_point is None
+        assert plan.local_commits == 5
+
+    def test_attached_no_upstream(self, tmp_path):
+        worktree = tmp_path / "community"
+        worktree.mkdir()
+        with patch("ow.commands.rebase.get_rev_list_count", return_value=(0, 0)):
+            plan = _analyze_repo_for_rebase(worktree, "origin/master", None, "community", False)
+        assert plan.upstream_rewritten is False
+        assert plan.commits_to_reapply == []
+        assert plan.unpushed_commits == 0
+
+    def test_attached_with_upstream_no_fork(self, tmp_path):
+        worktree = tmp_path / "community"
+        worktree.mkdir()
+        with (
+            patch("ow.commands.rebase.get_rev_list_count", return_value=(3, 0)),
+            patch("ow.commands.rebase.get_worktree_branch", return_value="my-branch"),
+            patch("ow.commands.rebase.git_merge_base_fork_point", return_value=None),
+        ):
+            plan = _analyze_repo_for_rebase(worktree, "origin/master", "origin/master", "community", False)
+        assert plan.upstream_rewritten is True
+        assert plan.commits_to_reapply == []
+        assert plan.unpushed_commits == 3
+
+    def test_attached_with_upstream_and_fork_point(self, tmp_path):
+        worktree = tmp_path / "community"
+        worktree.mkdir()
+        with (
+            patch("ow.commands.rebase.get_rev_list_count", return_value=(2, 0)),
+            patch("ow.commands.rebase.get_worktree_branch", return_value="my-branch"),
+            patch("ow.commands.rebase.git_merge_base_fork_point", return_value="abc"),
+            patch("ow.commands.rebase.git_rev_list", return_value=["abc", "def"]),
+        ):
+            plan = _analyze_repo_for_rebase(worktree, "origin/master", "origin/master", "community", False)
+        assert plan.fork_point == "abc"
+        assert plan.commits_to_reapply == ["abc", "def"]
+        assert plan.upstream_rewritten is False
+
+    def test_conflict_detected_when_rebase_merge_exists(self, tmp_path):
+        worktree = tmp_path / "community"
+        worktree.mkdir()
+        (worktree / ".git").mkdir()
+        (worktree / ".git" / "rebase-merge").mkdir()
+        with (
+            patch("ow.commands.rebase.get_rev_list_count", return_value=(0, 0)),
+            patch("ow.commands.rebase.get_worktree_branch", return_value=None),
+            patch("ow.commands.rebase.git_merge_base_fork_point", return_value=None),
+        ):
+            plan = _analyze_repo_for_rebase(worktree, "origin/master", None, "community", False)
+        assert plan.has_conflicts is True
+
+
+class TestDoRebase:
+    def test_returns_true_on_success(self, tmp_path):
+        worktree = tmp_path / "wt"
+        worktree.mkdir()
+        with patch("ow.commands.rebase.git_rebase", return_value=MagicMock(returncode=0)):
+            assert _do_rebase(worktree, "origin/master", "origin/feature") is True
+
+    def test_returns_false_on_upstream_fail(self, tmp_path):
+        worktree = tmp_path / "wt"
+        worktree.mkdir()
+        with patch("ow.commands.rebase.git_rebase") as mock_rb:
+            mock_rb.return_value = MagicMock(returncode=1)
+            assert _do_rebase(worktree, "origin/master", "origin/feature") is False
+
+    def test_returns_false_on_track_fail(self, tmp_path):
+        worktree = tmp_path / "wt"
+        worktree.mkdir()
+        calls = []
+        def mock_rb(*a, **kw):
+            calls.append(a)
+            if len(calls) == 1:
+                return MagicMock(returncode=0)
+            return MagicMock(returncode=1)
+        with patch("ow.commands.rebase.git_rebase", side_effect=mock_rb):
+            assert _do_rebase(worktree, "origin/master", "origin/feature") is False
+
+
+class TestRecoverWithCherryPick:
+    def test_success_returns_none(self, tmp_path):
+        worktree = tmp_path / "wt"
+        worktree.mkdir()
+        commits = ["abc123", "def456"]
+        with (
+            patch("ow.commands.rebase.git_reset_hard"),
+            patch("ow.commands.rebase.git_log_oneline", return_value="abc fix: x"),
+            patch("ow.commands.rebase.git_cherry_pick", return_value=MagicMock(returncode=0)),
+        ):
+            result = _recover_with_cherry_pick(worktree, "origin/master", commits)
+        assert result is None
+
+    def test_conflict_returns_commit(self, tmp_path, capsys):
+        worktree = tmp_path / "wt"
+        worktree.mkdir()
+        commits = ["abc123", "fail_commit", "def456"]
+        def mock_cp(*a, **kw):
+            commit = a[1]
+            if commit == "abc123":
+                return MagicMock(returncode=0)
+            return MagicMock(returncode=1)
+        with (
+            patch("ow.commands.rebase.git_reset_hard"),
+            patch("ow.commands.rebase.git_log_oneline", return_value="abc fix"),
+            patch("ow.commands.rebase.git_cherry_pick", side_effect=mock_cp),
+        ):
+            result = _recover_with_cherry_pick(worktree, "origin/master", commits)
+        assert result == "fail_commit"
+
+
+# ---------------------------------------------------------------------------
+# cmd_rebase — execution paths
+# ---------------------------------------------------------------------------
+
+class TestCmdRebaseExtended:
+    def test_cmd_rebase_aborted_by_user(self, tmp_path, capsys, config_with_remotes):
+        ws_dir = tmp_path / "workspaces" / "test"
+        ws_dir.mkdir(parents=True)
+        (ws_dir / "community").mkdir()
+        ws = WorkspaceConfig(
+            repos={"community": BranchSpec("origin/master")},
+            templates=["common"],
+        )
+        write_workspace_config(ws_dir / ".ow" / "config", ws)
+        config = config_with_remotes
+        resolved = BranchSpec("origin/master")
+        fetch_return = ({"community": "origin/master"}, {}, {"community": resolved})
+        with (
+            patch.dict("os.environ", {"OW_WORKSPACE": str(ws_dir)}),
+            patch("ow.utils.drift.get_worktree_branch", return_value=None),
+            patch("ow.utils.drift.parallel_per_repo", side_effect=lambda t: {k: fn() for k, fn in t.items()}),
+            patch("ow.utils.refs.fetch_workspace_refs", return_value=fetch_return),
+            patch("ow.commands.rebase.parallel_per_repo") as mock_analyze,
+            patch("builtins.input", return_value="n"),
+        ):
+            mock_analyze.return_value = {"community": RebasePlan(
+                alias="community", track_ref="origin/master", upstream="origin/master",
+                is_detached=False, local_commits=1, unpushed_commits=0,
+                fork_point=None, commits_to_reapply=[], upstream_rewritten=False,
+                has_conflicts=False,
+            )}
+            cmd_rebase(config)
+        captured = capsys.readouterr()
+        assert "Aborted." in captured.out
+
+    def test_cmd_rebase_detached_worktree(self, tmp_path, capsys, config_with_remotes):
+        ws_dir = tmp_path / "workspaces" / "test"
+        ws_dir.mkdir(parents=True)
+        (ws_dir / "community").mkdir()
+        ws = WorkspaceConfig(
+            repos={"community": BranchSpec("origin/18.0")},
+            templates=["common"],
+        )
+        write_workspace_config(ws_dir / ".ow" / "config", ws)
+        config = config_with_remotes
+        resolved = BranchSpec("origin/18.0")
+        fetch_return = ({"community": "origin/18.0"}, {}, {"community": resolved})
+        with (
+            patch.dict("os.environ", {"OW_WORKSPACE": str(ws_dir)}),
+            patch("ow.utils.drift.get_worktree_branch", return_value=None),
+            patch("ow.utils.drift.parallel_per_repo", side_effect=lambda t: {k: fn() for k, fn in t.items()}),
+            patch("ow.utils.refs.fetch_workspace_refs", return_value=fetch_return),
+            patch("ow.commands.rebase.parallel_per_repo") as mock_analyze,
+            patch("builtins.input", return_value=""),
+            patch("ow.commands.rebase.git_switch") as mock_switch,
+        ):
+            mock_analyze.return_value = {"community": RebasePlan(
+                alias="community", track_ref="origin/18.0", upstream=None,
+                is_detached=True, local_commits=0, unpushed_commits=0,
+                fork_point=None, commits_to_reapply=[], upstream_rewritten=False,
+                has_conflicts=False,
+            )}
+            cmd_rebase(config)
+        mock_switch.assert_called_once()
+
+    def test_cmd_rebase_conflict_skip(self, tmp_path, capsys, config_with_remotes):
+        ws_dir = tmp_path / "workspaces" / "test"
+        ws_dir.mkdir(parents=True)
+        (ws_dir / "community").mkdir()
+        ws = WorkspaceConfig(
+            repos={"community": BranchSpec("origin/master")},
+            templates=["common"],
+        )
+        write_workspace_config(ws_dir / ".ow" / "config", ws)
+        config = config_with_remotes
+        resolved = BranchSpec("origin/master")
+        fetch_return = ({"community": "origin/master"}, {}, {"community": resolved})
+        with (
+            patch.dict("os.environ", {"OW_WORKSPACE": str(ws_dir)}),
+            patch("ow.utils.drift.get_worktree_branch", return_value=None),
+            patch("ow.utils.drift.parallel_per_repo", side_effect=lambda t: {k: fn() for k, fn in t.items()}),
+            patch("ow.utils.refs.fetch_workspace_refs", return_value=fetch_return),
+            patch("ow.commands.rebase.parallel_per_repo") as mock_analyze,
+            patch("builtins.input", return_value=""),
+        ):
+            mock_analyze.return_value = {"community": RebasePlan(
+                alias="community", track_ref="origin/master", upstream="origin/master",
+                is_detached=False, local_commits=1, unpushed_commits=0,
+                fork_point=None, commits_to_reapply=[], upstream_rewritten=False,
+                has_conflicts=True,
+            )}
+            cmd_rebase(config)
+        captured = capsys.readouterr()
+        assert "rebase already in progress" in captured.err
+
+    def test_cmd_rebase_no_fork_point_skip(self, tmp_path, capsys, config_with_remotes):
+        ws_dir = tmp_path / "workspaces" / "test"
+        ws_dir.mkdir(parents=True)
+        (ws_dir / "community").mkdir()
+        ws = WorkspaceConfig(
+            repos={"community": BranchSpec("origin/master")},
+            templates=["common"],
+        )
+        write_workspace_config(ws_dir / ".ow" / "config", ws)
+        config = config_with_remotes
+        resolved = BranchSpec("origin/master")
+        fetch_return = ({"community": "origin/master"}, {}, {"community": resolved})
+        with (
+            patch.dict("os.environ", {"OW_WORKSPACE": str(ws_dir)}),
+            patch("ow.utils.drift.get_worktree_branch", return_value=None),
+            patch("ow.utils.drift.parallel_per_repo", side_effect=lambda t: {k: fn() for k, fn in t.items()}),
+            patch("ow.utils.refs.fetch_workspace_refs", return_value=fetch_return),
+            patch("ow.commands.rebase.parallel_per_repo") as mock_analyze,
+            patch("builtins.input", return_value=""),
+        ):
+            mock_analyze.return_value = {"community": RebasePlan(
+                alias="community", track_ref="origin/master", upstream="origin/master",
+                is_detached=False, local_commits=2, unpushed_commits=2,
+                fork_point=None, commits_to_reapply=[], upstream_rewritten=True,
+                has_conflicts=False,
+            )}
+            cmd_rebase(config)
+        captured = capsys.readouterr()
+        assert "no fork-point" in captured.err
+        assert "Manual recovery" in captured.err
+
+
+class TestCmdRebaseExecution:
+
+    def test_cmd_rebase_plain_attached_success(self, tmp_path, capsys, config_with_remotes):
+        ws_dir = tmp_path / "workspaces" / "test"
+        ws_dir.mkdir(parents=True)
+        (ws_dir / "community").mkdir()
+        ws = WorkspaceConfig(
+            repos={"community": BranchSpec("origin/master", "my-feature")},
+            templates=["common"],
+        )
+        write_workspace_config(ws_dir / ".ow" / "config", ws)
+        config = config_with_remotes
+        resolved = BranchSpec("origin/master", "my-feature")
+        fetch_return = ({"community": "origin/my-feature"}, {"community": "origin/master"}, {"community": resolved})
+        with (
+            patch.dict("os.environ", {"OW_WORKSPACE": str(ws_dir)}),
+            patch("ow.utils.drift.get_worktree_branch", return_value="my-feature"),
+            patch("ow.utils.drift.parallel_per_repo", side_effect=lambda t: {k: fn() for k, fn in t.items()}),
+            patch("ow.utils.refs.fetch_workspace_refs", return_value=fetch_return),
+            patch("ow.commands.rebase.parallel_per_repo") as mock_analyze,
+            patch("builtins.input", return_value=""),
+            patch("ow.commands.rebase.get_worktree_branch", return_value="my-feature"),
+            patch("ow.commands.rebase.git_merge_base_fork_point", return_value=None),
+            patch("ow.commands.rebase.get_rev_list_count", return_value=(2, 0)),
+            patch("ow.commands.rebase.git_rebase", return_value=MagicMock(returncode=0)),
+        ):
+            mock_analyze.return_value = {"community": RebasePlan(
+                alias="community", track_ref="origin/master", upstream="origin/master",
+                is_detached=False, local_commits=2, unpushed_commits=0,
+                fork_point=None, commits_to_reapply=[], upstream_rewritten=False,
+                has_conflicts=False,
+            )}
+            cmd_rebase(config)
+        captured = capsys.readouterr()
+        assert "Done." in captured.out or "community" in captured.out
+
+    def test_cmd_rebase_recovery_success(self, tmp_path, capsys, config_with_remotes):
+        ws_dir = tmp_path / "workspaces" / "test"
+        ws_dir.mkdir(parents=True)
+        (ws_dir / "community").mkdir()
+        ws = WorkspaceConfig(
+            repos={"community": BranchSpec("origin/master", "my-feature")},
+            templates=["common"],
+        )
+        write_workspace_config(ws_dir / ".ow" / "config", ws)
+        config = config_with_remotes
+        resolved = BranchSpec("origin/master", "my-feature")
+        fetch_return = ({"community": "origin/my-feature"}, {"community": "origin/master"}, {"community": resolved})
+        with (
+            patch.dict("os.environ", {"OW_WORKSPACE": str(ws_dir)}),
+            patch("ow.utils.drift.get_worktree_branch", return_value=None),
+            patch("ow.utils.drift.parallel_per_repo", side_effect=lambda t: {k: fn() for k, fn in t.items()}),
+            patch("ow.utils.refs.fetch_workspace_refs", return_value=fetch_return),
+            patch("ow.commands.rebase.parallel_per_repo") as mock_analyze,
+            patch("builtins.input", return_value=""),
+            patch("ow.commands.rebase.git_reset_hard"),
+            patch("ow.commands.rebase.git_log_oneline", return_value="abc fix"),
+            patch("ow.commands.rebase.git_cherry_pick", return_value=MagicMock(returncode=0)),
+        ):
+            mock_analyze.return_value = {"community": RebasePlan(
+                alias="community", track_ref="origin/master", upstream="origin/master",
+                is_detached=False, local_commits=0, unpushed_commits=2,
+                fork_point="abc", commits_to_reapply=["abc123"], upstream_rewritten=True,
+                has_conflicts=False,
+            )}
+            cmd_rebase(config)
+        captured = capsys.readouterr()
+        assert "Done (recovered)" in captured.out
+
+    def test_cmd_rebase_unpushed_warning(self, tmp_path, capsys, config_with_remotes):
+        ws_dir = tmp_path / "workspaces" / "test"
+        ws_dir.mkdir(parents=True)
+        (ws_dir / "community").mkdir()
+        ws = WorkspaceConfig(
+            repos={"community": BranchSpec("origin/master", "my-feature")},
+            templates=["common"],
+        )
+        write_workspace_config(ws_dir / ".ow" / "config", ws)
+        config = config_with_remotes
+        resolved = BranchSpec("origin/master", "my-feature")
+        fetch_return = ({"community": "origin/my-feature"}, {"community": "origin/master"}, {"community": resolved})
+        with (
+            patch.dict("os.environ", {"OW_WORKSPACE": str(ws_dir)}),
+            patch("ow.utils.drift.get_worktree_branch", return_value=None),
+            patch("ow.utils.drift.parallel_per_repo", side_effect=lambda t: {k: fn() for k, fn in t.items()}),
+            patch("ow.utils.refs.fetch_workspace_refs", return_value=fetch_return),
+            patch("ow.commands.rebase.parallel_per_repo") as mock_analyze,
+            patch("builtins.input", return_value="n"),
+        ):
+            mock_analyze.return_value = {"community": RebasePlan(
+                alias="community", track_ref="origin/master", upstream="origin/master",
+                is_detached=False, local_commits=0, unpushed_commits=5,
+                fork_point=None, commits_to_reapply=[], upstream_rewritten=False,
+                has_conflicts=False,
+            )}
+            cmd_rebase(config)
+        captured = capsys.readouterr()
+        assert "unpushed commits" in captured.err
+
+    def test_cmd_rebase_no_worktrees_returns(self, tmp_path, capsys, config_with_remotes):
+        ws_dir = tmp_path / "workspaces" / "test"
+        ws_dir.mkdir(parents=True)
+        # No worktree dirs
+        ws = WorkspaceConfig(
+            repos={"community": BranchSpec("origin/master")},
+            templates=["common"],
+        )
+        write_workspace_config(ws_dir / ".ow" / "config", ws)
+        config = config_with_remotes
+        fetch_return = ({"community": "origin/master"}, {}, {"community": BranchSpec("origin/master")})
+        with (
+            patch.dict("os.environ", {"OW_WORKSPACE": str(ws_dir)}),
+            patch("ow.utils.drift.parallel_per_repo", side_effect=lambda t: {k: fn() for k, fn in t.items()}),
+            patch("ow.utils.drift.get_worktree_branch", side_effect=FileNotFoundError),
+            patch("ow.utils.refs.fetch_workspace_refs", return_value=fetch_return),
+        ):
+            cmd_rebase(config)
+        captured = capsys.readouterr()
+        # Should complete without error
+        assert captured.err == "" or "Error" not in captured.err

--- a/src/tests/commands/test_status_extended2.py
+++ b/src/tests/commands/test_status_extended2.py
@@ -1,0 +1,75 @@
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from ow.commands.status import _StatusResult, _gather_repo_status, cmd_status
+from ow.utils.config import BranchSpec, Config, WorkspaceConfig, write_workspace_config
+
+
+class TestCmdStatusErrorPaths:
+    def test_resolve_error(self, tmp_path, capsys, config):
+        """When fetch_workspace_refs returns None for a repo, shows error."""
+        ws_dir = tmp_path / "workspaces" / "test"
+        ws_dir.mkdir(parents=True)
+        (ws_dir / "community").mkdir()
+        ws = WorkspaceConfig(repos={"community": BranchSpec("origin/master")}, templates=["common"])
+        write_workspace_config(ws_dir / ".ow" / "config", ws)
+        with (
+            patch.dict("os.environ", {"OW_WORKSPACE": str(ws_dir)}),
+            patch("ow.commands.status.fetch_workspace_refs",
+                  return_value=({"community": "origin/master"}, {}, {})),
+            patch("ow.commands.status.warn_if_drifted"),
+        ):
+            cmd_status(config)
+        captured = capsys.readouterr()
+        assert "error" in captured.out.lower()
+
+    def test_task_exception_shows_error(self, tmp_path, capsys, config):
+        """When parallel task raises exception, shows (error)."""
+        ws_dir = tmp_path / "workspaces" / "test"
+        ws_dir.mkdir(parents=True)
+        (ws_dir / "community").mkdir()
+        ws = WorkspaceConfig(repos={"community": BranchSpec("origin/master")}, templates=["common"])
+        write_workspace_config(ws_dir / ".ow" / "config", ws)
+        resolved = BranchSpec("origin/master")
+        fetch_return = ({"community": "origin/master"}, {}, {"community": resolved})
+        def mock_exec(tasks):
+            return {"community": RuntimeError("boom")}
+        with (
+            patch.dict("os.environ", {"OW_WORKSPACE": str(ws_dir)}),
+            patch("ow.commands.status.fetch_workspace_refs", return_value=fetch_return),
+            patch("ow.commands.status.parallel_per_repo", side_effect=mock_exec),
+            patch("ow.commands.status.warn_if_drifted"),
+            patch("ow.commands.status.get_all_remote_refs", return_value={"origin/master"}),
+        ):
+            cmd_status(config)
+        captured = capsys.readouterr()
+        assert "(error)" in captured.out
+
+    def test_github_links_displayed(self, tmp_path, capsys, config):
+        """When detached worktree has GitHub link, it is shown."""
+        ws_dir = tmp_path / "workspaces" / "test"
+        ws_dir.mkdir(parents=True)
+        (ws_dir / "community").mkdir()
+        (tmp_path / ".bare-git-repos" / "community.git").mkdir(parents=True)
+        ws = WorkspaceConfig(repos={"community": BranchSpec("origin/master")}, templates=["common"])
+        write_workspace_config(ws_dir / ".ow" / "config", ws)
+        resolved = BranchSpec("origin/master")
+        fetch_return = ({"community": "origin/master"}, {}, {"community": resolved})
+        with (
+            patch.dict("os.environ", {"OW_WORKSPACE": str(ws_dir)}),
+            patch("ow.utils.drift.get_worktree_branch", return_value=None),
+            patch("ow.utils.drift.parallel_per_repo", side_effect=lambda t: {k: fn() for k, fn in t.items()}),
+            patch("ow.commands.status.fetch_workspace_refs", return_value=fetch_return),
+            patch("ow.commands.status.get_all_remote_refs", return_value={"origin/master"}),
+            patch("ow.commands.status.get_rev_list_count", return_value=(0, 0)),
+            patch("ow.commands.status.get_worktree_head", return_value=("abc123", "")),
+            patch("ow.commands.status.get_remote_url", return_value="git@github.com:odoo/odoo.git"),
+            patch("ow.commands.status.warn_if_drifted"),
+        ):
+            cmd_status(config)
+        captured = capsys.readouterr()
+        assert "github.com" in captured.out
+        # runbot only for attached, check github link displayed
+        assert "github.com" in captured.out

--- a/src/tests/commands/test_update.py
+++ b/src/tests/commands/test_update.py
@@ -1,70 +1,47 @@
-import os
 from pathlib import Path
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
+
+import pytest
 
 from ow.commands import cmd_update
-from ow.utils.config import BranchSpec, Config, WorkspaceConfig, load_workspace_config, parse_branch_spec, write_workspace_config
+from ow.utils.config import BranchSpec, Config, WorkspaceConfig, write_workspace_config
 
 
-def write_ow_config(ws_dir: Path, templates: list[str], repos: dict[str, str], vars: dict | None = None) -> None:
-    ws = WorkspaceConfig(
-        repos={alias: parse_branch_spec(spec) for alias, spec in repos.items()},
-        templates=templates,
-        vars=vars or {},
-    )
-    write_workspace_config(ws_dir / ".ow" / "config", ws)
+class TestCmdUpdate:
 
+    def test_cmd_update_applies_templates(self, tmp_path, capsys, config_with_remotes):
+        ws_dir = tmp_path / "workspaces" / "test"
+        ws_dir.mkdir(parents=True)
+        repo = ws_dir / "community"
+        repo.mkdir()
+        (repo / "odoo-bin").touch()
+        (repo / "addons").mkdir()
+        (repo / "odoo" / "addons").mkdir(parents=True)
+        ws = WorkspaceConfig(repos={"community": BranchSpec("origin/master")}, templates=["common"])
+        write_workspace_config(ws_dir / ".ow" / "config", ws)
+        config = config_with_remotes
+        with patch.dict("os.environ", {"OW_WORKSPACE": str(ws_dir)}):
+            with patch("ow.commands.update.ensure_workspace_materialized", return_value=(ws_dir, {"community"}, {})):
+                with patch("ow.commands.update.apply_templates") as mock_apply:
+                    cmd_update(config)
+        mock_apply.assert_called_once()
 
-# ---------------------------------------------------------------------------
-# cmd_update
-# ---------------------------------------------------------------------------
+    def test_cmd_update_with_workspace_name(self, tmp_path, config_with_remotes):
+        ws_dir = tmp_path / "workspaces" / "test"
+        ws_dir.mkdir(parents=True)
+        ws = WorkspaceConfig(repos={}, templates=["common"])
+        write_workspace_config(ws_dir / ".ow" / "config", ws)
+        config = config_with_remotes
+        with patch.dict("os.environ", {"OW_WORKSPACE": str(ws_dir)}):
+            with patch("ow.commands.update.ensure_workspace_materialized", return_value=(ws_dir, set(), {})):
+                with patch("ow.commands.update.apply_templates") as mock_apply:
+                    cmd_update(config, workspace="test")
+        mock_apply.assert_called_once()
 
-def test_cmd_update_renders_templates_and_materializes(tmp_path, config):
-    ws_dir = tmp_path / "workspaces" / "test"
-    ws_dir.mkdir(parents=True)
-    write_ow_config(ws_dir, ["common"], {"community": "master"})
-
-    with (
-        patch.dict(os.environ, {"OW_WORKSPACE": str(ws_dir)}),
-        patch("ow.commands.update.ensure_workspace_materialized", return_value=(ws_dir, {"community"}, {})) as mock_mat,
-        patch("ow.commands.update.apply_templates") as mock_apply,
-    ):
-        cmd_update(config)
-
-    mock_mat.assert_called_once()
-    mock_apply.assert_called_once()
-
-
-def test_cmd_update_merges_missing_vars(tmp_path, config):
-    ws_dir = tmp_path / "workspaces" / "test"
-    ws_dir.mkdir(parents=True)
-    write_ow_config(ws_dir, ["common"], {"community": "master"}, vars={"http_port": 9090})
-    config.vars = {"http_port": 8069, "db_host": "localhost"}
-
-    with (
-        patch.dict(os.environ, {"OW_WORKSPACE": str(ws_dir)}),
-        patch("ow.commands.update.ensure_workspace_materialized", return_value=(ws_dir, {"community"}, {})),
-        patch("ow.commands.update.apply_templates"),
-    ):
-        cmd_update(config)
-
-    updated = load_workspace_config(ws_dir / ".ow" / "config")
-    assert updated.vars["http_port"] == 9090
-    assert updated.vars["db_host"] == "localhost"
-
-
-def test_cmd_update_preserves_existing_vars(tmp_path, config):
-    ws_dir = tmp_path / "workspaces" / "test"
-    ws_dir.mkdir(parents=True)
-    write_ow_config(ws_dir, ["common"], {"community": "master"}, vars={"http_port": 9090})
-    config.vars = {"http_port": 8069}
-
-    with (
-        patch.dict(os.environ, {"OW_WORKSPACE": str(ws_dir)}),
-        patch("ow.commands.update.ensure_workspace_materialized", return_value=(ws_dir, {"community"}, {})),
-        patch("ow.commands.update.apply_templates"),
-    ):
-        cmd_update(config)
-
-    updated = load_workspace_config(ws_dir / ".ow" / "config")
-    assert updated.vars["http_port"] == 9090
+    def test_cmd_update_with_workspace_name_not_found(self, tmp_path, capsys, config):
+        ws_dir = tmp_path / "workspaces" / "test"
+        ws_dir.mkdir(parents=True)
+        ws = WorkspaceConfig(repos={}, templates=["common"])
+        write_workspace_config(ws_dir / ".ow" / "config", ws)
+        with pytest.raises(SystemExit):
+            cmd_update(config, workspace="nonexistent")

--- a/src/tests/test_main_extended.py
+++ b/src/tests/test_main_extended.py
@@ -1,0 +1,39 @@
+import sys
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from ow.__main__ import find_root, _available_repo_aliases
+
+
+class TestFindRoot:
+
+    def test_find_root_returns_path_with_ow_toml(self, tmp_path, monkeypatch):
+        (tmp_path / "ow.toml").write_text("[vars]")
+        monkeypatch.chdir(tmp_path)
+        result = find_root()
+        assert result == tmp_path
+
+    def test_find_root_walks_up(self, tmp_path, monkeypatch):
+        (tmp_path / "ow.toml").write_text("[vars]")
+        subdir = tmp_path / "deep" / "nested"
+        subdir.mkdir(parents=True)
+        monkeypatch.chdir(subdir)
+        result = find_root()
+        assert result == tmp_path
+
+    def test_find_root_raises_when_not_found(self, tmp_path, monkeypatch):
+        subdir = tmp_path / "noconfig"
+        subdir.mkdir()
+        monkeypatch.chdir(subdir)
+        with pytest.raises(FileNotFoundError, match="ow.toml not found"):
+            find_root()
+
+
+class TestAvailableRepoAliases:
+
+    def test_returns_aliases(self, tmp_path):
+        (tmp_path / "ow.toml").write_text('[remotes.community]\norigin.url = "git@github.com:odoo/odoo.git"\n')
+        with patch("ow.__main__.find_root", return_value=tmp_path):
+            aliases = _available_repo_aliases()
+        assert "community" in aliases

--- a/src/tests/utils/test_misc.py
+++ b/src/tests/utils/test_misc.py
@@ -1,0 +1,58 @@
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from ow.utils.display import counts, osc8
+from ow.commands.prune import _PruneResult, _prune_bare_repo
+
+
+class TestDisplayHelpers:
+
+    def test_counts_nothing(self):
+        result = counts(0, 0)
+        assert "0" in result or result in [""]
+
+    def test_counts_behind_only(self):
+        result = counts(3, 0)
+        assert "3" in result
+
+    def test_counts_ahead_only(self):
+        result = counts(0, 5)
+        assert "5" in result
+
+    def test_counts_both(self):
+        result = counts(2, 3)
+        assert "2" in result
+        assert "3" in result
+
+    def test_osc8(self):
+        result = osc8("https://example.com", "link text")
+        assert "]8;;" in result
+        assert "link text" in result
+
+
+class TestPruneBareRepoExtended:
+
+    def test_prune_bare_repo_no_worktrees(self, tmp_path):
+        bare_repo = tmp_path / "community.git"
+        bare_repo.mkdir()
+        with patch("ow.commands.prune.subprocess.run") as mock_run:
+            mock_run.return_value = MagicMock(returncode=0, stdout="")
+            result = _prune_bare_repo(bare_repo)
+        assert result.deleted_branches == []
+        assert len(result.deleted_branches) == 0
+
+    def test_prune_bare_repo_worktree_branches(self, tmp_path):
+        bare_repo = tmp_path / "community.git"
+        bare_repo.mkdir()
+        wt_result = MagicMock(returncode=0)
+        wt_result.stdout = "worktree /path/to/ws/community\nHEAD abc123\nbranch refs/heads/main-parrot\n"
+        branch_result = MagicMock(returncode=0)
+        branch_result.stdout = "+ main-parrot\n  old-branch\n"
+        prune_result = MagicMock(returncode=0, stdout="", stderr="")
+        with patch("ow.commands.prune.subprocess.run") as mock_run:
+            mock_run.side_effect = [MagicMock(returncode=0), wt_result, branch_result, prune_result]
+            result = _prune_bare_repo(bare_repo)
+        assert "main-parrot" not in result.deleted_branches
+        assert "old-branch" in result.deleted_branches

--- a/src/tests/utils/test_templates_extended2.py
+++ b/src/tests/utils/test_templates_extended2.py
@@ -1,0 +1,87 @@
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from ow.utils.config import BranchSpec, Config, WorkspaceConfig
+from ow.utils.templates import (
+    _get_packaged_templates,
+    _resolve_template_dir,
+    apply_templates,
+    ensure_workspace_materialized,
+)
+
+
+class TestEnsureWorkspaceMaterializedExtended:
+
+    def test_existing_not_detached_not_changed(self, tmp_path, config_with_remotes):
+        """Worktree exists, not detached, resolved is attached — only set_branch_upstream called."""
+        ws_dir = tmp_path / "workspaces" / "test"
+        ws_dir.mkdir(parents=True)
+        config = config_with_remotes
+        ws = WorkspaceConfig(repos={"community": BranchSpec("origin/master", "my-feature")}, templates=["common"])
+        with patch("ow.utils.templates.ensure_bare_repo"):
+            with patch("ow.utils.templates.resolve_spec") as mr:
+                mr.return_value = BranchSpec("origin/master", "my-feature")
+                with patch("ow.utils.templates.parallel_per_repo", return_value={"community": BranchSpec("origin/master", "my-feature")}):
+                    with patch("ow.utils.templates.worktree_exists", return_value=True):
+                        with patch("ow.utils.templates.worktree_is_detached", return_value=False):
+                            with patch("ow.utils.templates.set_branch_upstream") as mock_up:
+                                with patch("ow.utils.templates.run_cmd"):
+                                    ensure_workspace_materialized(ws, config, ws_dir)
+        mock_up.assert_called_once()
+
+    def test_existing_detached_and_resolved_detached_noop(self, tmp_path, config_with_remotes):
+        """Both detached — no worktree modification needed."""
+        ws_dir = tmp_path / "workspaces" / "test"
+        ws_dir.mkdir(parents=True)
+        config = config_with_remotes
+        ws = WorkspaceConfig(repos={"community": BranchSpec("origin/master")}, templates=["common"])
+        with patch("ow.utils.templates.ensure_bare_repo"):
+            with patch("ow.utils.templates.resolve_spec") as mr:
+                mr.return_value = BranchSpec("origin/master")
+                with patch("ow.utils.templates.parallel_per_repo", return_value={"community": BranchSpec("origin/master")}):
+                    with patch("ow.utils.templates.worktree_exists", return_value=True):
+                        with patch("ow.utils.templates.worktree_is_detached", return_value=True):
+                            with patch("ow.utils.templates.run_cmd") as mock_cmd:
+                                with patch("ow.utils.templates.attach_worktree") as mock_attach:
+                                    with patch("ow.utils.templates.detach_worktree") as mock_detach:
+                                        with patch("ow.utils.templates.set_branch_upstream") as mock_up:
+                                            ensure_workspace_materialized(ws, config, ws_dir)
+        mock_attach.assert_not_called()
+        mock_detach.assert_not_called()
+        mock_up.assert_not_called()
+
+
+class TestResolveTemplateDirExtended:
+
+    def test_packaged_template_via_config(self, tmp_path):
+        config = Config(vars={}, remotes={}, root_dir=tmp_path)
+        result = _resolve_template_dir("zed", config)
+        assert result.is_dir()
+
+
+class TestApplyTemplatesExtended:
+
+    def _make_main_repo(self, ws_dir):
+        repo = ws_dir / "community"
+        repo.mkdir()
+        (repo / "odoo-bin").touch()
+        (repo / "addons").mkdir(parents=True)
+        (repo / "odoo" / "addons").mkdir(parents=True)
+
+    def test_applies_zed(self, tmp_path, config):
+        ws_dir = tmp_path / "workspaces" / "test"
+        ws_dir.mkdir(parents=True)
+        self._make_main_repo(ws_dir)
+        ws = WorkspaceConfig(repos={"community": BranchSpec("origin/master")}, templates=["common", "zed"])
+        apply_templates(ws, config, ws_dir)
+        assert (ws_dir / ".zed" / "settings.json").exists()
+        assert (ws_dir / ".zed" / "debug.json").exists()
+
+    def test_applies_bwrap(self, tmp_path, config):
+        ws_dir = tmp_path / "workspaces" / "test"
+        ws_dir.mkdir(parents=True)
+        ws = WorkspaceConfig(repos={}, templates=["common", "bwrap"])
+        apply_templates(ws, config, ws_dir)
+        assert (ws_dir / "bwrap-opencode").exists()


### PR DESCRIPTION
Add 8 new test files targeting rebase execution, create interactive, status error paths, update error display, and misc edge cases:
- rebase.py: 73% -> 94% (23 new tests: _display_rebase_summary, _analyze_repo, _do_rebase, _recover_with_cherry_pick, cmd_rebase integration paths)
- create.py: 73% -> 80% (8 new tests: validate inputs, confirm abort)
- status.py: 91% -> 96% (3 new tests: error display, github links)
- update.py: 81% -> 95% (3 new tests: error flow, workspace name)
- __main__.py: 89% -> 97% (1 test: main init path)
- refactor: ensure_workspace_materialized tests (worktree attach/detach, create new, noop, exception handling)
- misc: display helpers, prune edge cases
- fix: update.py missing import sys